### PR TITLE
Check site page url properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sppagecontextinfo",
   "description": "_spPageContextInfo object for SharePoint classic and modern sites",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "author": {
     "name": "Tomasz Wojtasik",
     "email": "tomaszoida@o2.pl"

--- a/src/SPPageContextInfo.ts
+++ b/src/SPPageContextInfo.ts
@@ -40,6 +40,7 @@ export class SPPageContextInfo {
                     resolve(newContext)
                 }
 
+                observedURL = this.trimSlash(observedURL);
                 if (observedURL.toLowerCase() !== absoluteUrl.toLowerCase() && 
                     observedURL.toLowerCase() !== newContext.webAbsoluteUrl.toLowerCase()) 
                 {
@@ -58,5 +59,12 @@ export class SPPageContextInfo {
 
     private static getAbsoluteUrl( context: any){
         return window.location.origin + context.serverRequestPath
+    }
+
+    private static trimSlash(urlString: string){
+        if(urlString.endsWith('/')){
+            return urlString.slice(0, -1)
+        }
+        return urlString
     }
 }

--- a/src/SPPageContextInfo.ts
+++ b/src/SPPageContextInfo.ts
@@ -28,9 +28,9 @@ export class SPPageContextInfo {
         return new Promise(resolve => {
 
             var counter = 0;
-            var contextURL: string = context.webAbsoluteUrl;
             var newContext = context;
             var maxCount = Math.ceil(timeoutMillis / intervalTimeMillis);
+            var absoluteUrl = this.getAbsoluteUrl(newContext)
 
             var interval = setInterval(() => {
                 counter++;
@@ -39,12 +39,12 @@ export class SPPageContextInfo {
                     console.error('SPPageContextInfo: Could not get new context because of timeout')
                     resolve(newContext)
                 }
-                observedURL = this.splitURL(observedURL)["beforeSitePageURL"]
-                if (!(observedURL === contextURL.toLowerCase())) {
+
+                if (!(observedURL.toLowerCase() === absoluteUrl.toLowerCase())) {
                     SPPageContextInfo.contextChooser().then(spPageContext => {
                         newContext = spPageContext;
-                        contextURL = newContext.webAbsoluteUrl;
-                    })
+                        absoluteUrl = this.getAbsoluteUrl(newContext)
+                    });
 
                 } else {
                     clearInterval(interval)
@@ -54,12 +54,7 @@ export class SPPageContextInfo {
         })
     }
 
-    private static splitURL(url: string) {
-        url = url.toLowerCase();
-        if (url.includes('/sitepages/')) {
-            var splittedUrl = url.split('/sitepages/')
-            return { beforeSitePageURL: splittedUrl[0], afterSitePageURL: splittedUrl[1] }
-        }
-        return { beforeSitePageURL: url, afterSitePageURL: "" }
+    private static getAbsoluteUrl( context: any){
+        return window.location.origin + context.serverRequestPath
     }
 }

--- a/src/SPPageContextInfo.ts
+++ b/src/SPPageContextInfo.ts
@@ -39,7 +39,8 @@ export class SPPageContextInfo {
                     console.error('SPPageContextInfo: Could not get new context because of timeout')
                     resolve(newContext)
                 }
-                if (!observedURL.toLowerCase().startsWith(contextURL.toLowerCase())) {
+                observedURL = this.splitURL(observedURL)["beforeSitePageURL"]
+                if (!(observedURL === contextURL.toLowerCase())) {
                     SPPageContextInfo.contextChooser().then(spPageContext => {
                         newContext = spPageContext;
                         contextURL = newContext.webAbsoluteUrl;
@@ -51,5 +52,14 @@ export class SPPageContextInfo {
                 }
             }, intervalTimeMillis)
         })
+    }
+
+    private static splitURL(url: string) {
+        url = url.toLowerCase();
+        if (url.includes('/sitepages/')) {
+            var splittedUrl = url.split('/sitepages/')
+            return { beforeSitePageURL: splittedUrl[0], afterSitePageURL: splittedUrl[1] }
+        }
+        return { beforeSitePageURL: url, afterSitePageURL: "" }
     }
 }

--- a/src/SPPageContextInfo.ts
+++ b/src/SPPageContextInfo.ts
@@ -40,7 +40,9 @@ export class SPPageContextInfo {
                     resolve(newContext)
                 }
 
-                if (!(observedURL.toLowerCase() === absoluteUrl.toLowerCase())) {
+                if (observedURL.toLowerCase() !== absoluteUrl.toLowerCase() && 
+                    observedURL.toLowerCase() !== newContext.webAbsoluteUrl.toLowerCase()) 
+                {
                     SPPageContextInfo.contextChooser().then(spPageContext => {
                         newContext = spPageContext;
                         absoluteUrl = this.getAbsoluteUrl(newContext)


### PR DESCRIPTION
Change way of comparing present URL from window with previous one in pageContext. All relies on splitting url from window with 'sitepages' string, then we have relative url, same as stored in pageContext. These changes were proposed because of bad context when starting from HomePage and redirect to some sitepage (Context from home page left).